### PR TITLE
API: Fixed init BaseService

### DIFF
--- a/src/app-ropio/AppRopio.Base/API/Services/_base/BaseService.cs
+++ b/src/app-ropio/AppRopio.Base/API/Services/_base/BaseService.cs
@@ -36,7 +36,7 @@ namespace AppRopio.Base.API.Services
             _lazyTrace = new Lazy<IMvxTrace>(() => _trace ?? Mvx.Resolve<IMvxTrace>());
         }
 
-        protected BaseService(IConnectionService connectionService, IMvxTrace trace)
+        protected BaseService(IConnectionService connectionService, IMvxTrace trace) : this()
         {
             _connectionService = connectionService;
             _trace = trace;


### PR DESCRIPTION
Fixed NPE when call ConnectionService,  if create BaseService via constructor with params 